### PR TITLE
Fix non zero-index encoded characters

### DIFF
--- a/src/JsonTests/JsonTests.cs
+++ b/src/JsonTests/JsonTests.cs
@@ -131,6 +131,9 @@ namespace UnitTests
             TestEncodeDecode('\0', @"""\u0000""");
             TestEncodeDecode((char)1, @"""\u0001""");
 
+            // non zero-index encoded characters
+            TestEncodeDecode(@"c:\directory\file.txt", @"""c:\\directory\\file.txt""");
+
             TestEncode("/", @"""/"""); // doesn't need to be encoded.
             TestDecode(@"""\/""", "/"); // but can be decoded.
 

--- a/src/argo/Json_Encoder.cs
+++ b/src/argo/Json_Encoder.cs
@@ -77,7 +77,11 @@ namespace Argo
                         case '\\':
                             return true;
                         default:
-                            return char.IsControl(ch);
+                            if (char.IsControl(ch))
+                            {
+                                return true;
+                            }
+                            break;
                     }
                 }
 


### PR DESCRIPTION
JsonEncoder.NeedsEscaping(string) only ever tested the first character.
